### PR TITLE
Fix interpreting content-type with additional directives

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -22,7 +22,7 @@ class Request
 
         $server['CONTENT_TYPE'] = isset($server['CONTENT_TYPE']) ? $server['CONTENT_TYPE'] : '';
 
-        if ($server['CONTENT_TYPE'] == 'application/json') {
+        if (preg_match('/^application\/json.*/', $server['CONTENT_TYPE'])) {
             $postData = file_get_contents('php://input');
             $post = json_decode($postData, true);
         }


### PR DESCRIPTION
There may be directives like `charset=utf-8` written in header as `Content-Type: application/json;charset=utf-8`.